### PR TITLE
If !@focusModeSettings.fullScreen, don't exit fullscreen

### DIFF
--- a/lib/focus-mode-manager.coffee
+++ b/lib/focus-mode-manager.coffee
@@ -44,7 +44,7 @@ class FocusModeManager extends FocusModeBase
 
 
     exitFullScreen: =>
-        atom.setFullScreen(false) if atom.isFullScreen()
+        atom.setFullScreen(false) if @focusModeSettings.fullScreen
 
 
     registerCursorEventHandlers: =>


### PR DESCRIPTION
Currently, even if "Enter Full Screen" in Settings is unchecked, exiting focus mode will exit fullscreen.